### PR TITLE
docs: fix 80 typos and grammar issues across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ByteQC is a high-performance, GPU-accelerated quantum chemistry package designed for large-scale quantum chemistry simulations. It currently supports a range of methods, including mean-field calculations for both open and periodic boundary conditions, MP2 simulations, CCSD, and CCSD(T) calculations. All of these methods are optimized to support multiple GPUs, enabling efficient parallelization.
 Additionally, ByteQC includes an integrated functionality for systematically improvable embedding (SIE), which allows for scalable simulations of complex systems. The package also exports several useful tools for the development of GPU-based quantum chemistry applications.
 
-## Exteranl dependencies
+## External dependencies
 
 This package incorporates parts of its code adapted from several external open-source projects:
 
@@ -29,12 +29,12 @@ GPU requirement: test on NVIDIA V100, A100, H100, and 4070Ti.
 - scipy
 - pyscf =2.5.0
 
-Build dependencied:
+Build dependencies:
 
 - libcutensor >=2.1.0.9 (installation from conda is also supported)
 - libcublas
 
-Build the package by run command `python byteqc/setup.py`.
+Build the package by running the command `python byteqc/setup.py`.
 
 ## Package structure
 

--- a/cucc/README.md
+++ b/cucc/README.md
@@ -1,5 +1,5 @@
 # `cucc` subpackage
 
-This packages follows the interfaces in PySCF packages, and some codes are adapted from it to keep the same interface. The examples are in the `byteqc/cucc/test` folder.
+This package follows the interfaces in PySCF packages, and some codes are adapted from it to keep the same interface. The examples are in the `byteqc/cucc/test` folder.
 
 The `buffer.py` and `culib.py` modules enable automatic backend determination. The arrays in `cucc` can be stored on the GPU, CPU, or disk, all with the same interface. Users and developers can work with these arrays without having to consider the underlying backend.

--- a/cump2/README.md
+++ b/cump2/README.md
@@ -1,11 +1,11 @@
 # `cump2` subpackage
 
 The cump2 subpackage provides GPU-accelerated MP2 calculations. It exports two functions: `DFMP2` and `DFKMP2`, which support both open boundary conditions (OBC) and periodic boundary conditions (PBC). For PBC, only gamma-point calculations are currently supported.
-The cump2 subpackage also provides the gradient of OBC DFMP2 as the function `DFMP2_grad`. But for now `DFMP2_grad` is treated as advance feature which need `gpu4pyscf`. We recommend users to install `gpu4pyscf` by using the following command.
+The cump2 subpackage also provides the gradient of OBC DFMP2 as the function `DFMP2_grad`. But for now `DFMP2_grad` is treated as an advanced feature which need `gpu4pyscf`. We recommend users to install `gpu4pyscf` by using the following command.
 ```shell
 pip install --no-deps gpu4pyscf-cuda12x==1.3.1 pyscf==2.8.0 pyscf-dispersion==1.3.0 geometric==1.1 gpu4pyscf-libxc-cuda12x==0.6 networkx==3.4.2
 ```
-Note that, the compatibility between `gpu4pyscf` and `byteqc` is not fully tested. If user find the functions do not work in `byteqc`. We recommend you to reset your environment by following the main document installation guide.
+Note that, the compatibility between `gpu4pyscf` and `byteqc` is not fully tested. If users find the functions do not work in `byteqc`. We recommend you to reset your environment by following the main document installation guide.
 
 Examples can be found in the following files:
 * `byteqc/cump2/tests/mp2.py``

--- a/cuobc/README.md
+++ b/cuobc/README.md
@@ -1,4 +1,4 @@
-This package is adapted form several opensource projects:
+This package is adapted from several opensource projects:
 
 * https://github.com/bytedance/gpu4pyscf
 * https://github.com/sunqm/libcint

--- a/embyte/README.md
+++ b/embyte/README.md
@@ -1,27 +1,27 @@
 # EmByte
-`EmByte` is a GPU-accelerated quantum chemistry software developed based on the [systematically improvable quantum embedding algorithm](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.12.011046), which is termed as SIE, combined with the high-perfermance quantum chemistry toolkit from ByteQC. In testing, CCSD(T)-level quantum chemistry calculations for systems with over 10,000 orbitals could be done on the machines with A100 GPUs with 80 GB of GPU memory.
+`EmByte` is a GPU-accelerated quantum chemistry software developed based on the [systematically improvable quantum embedding algorithm](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.12.011046), which is termed as SIE, combined with the high-performance quantum chemistry toolkit from ByteQC. In testing, CCSD(T)-level quantum chemistry calculations for systems with over 10,000 orbitals could be done on the machines with A100 GPUs with 80 GB of GPU memory.
 
 ## Feature
 ### Functions Supported
 Basically now EmByte supported
 
-1. Partition wavefunction form results, included the linear energy functional form and the reduced density matrix (RDM) form, are all supported, where the RDM form is more accurate due to the introduction of the inter-cluster information;
+1. Partition wavefunction form results, including the linear energy functional form and the reduced density matrix (RDM) form, are all supported, where the RDM form is more accurate due to the introduction of the inter-cluster information;
 2. MP2/CCSD could be used as the high-level solver, and the special-designed SIE-suitable in-situ perturbative (T) calculation is also accessible if the solver is CCSD and finally push the calculation accuracy to the level of CCSD(T);
-3. Supported fexible BNO thershould setting， which allows set different BNO threholds for clusters or set more than 1 threshold for the testing purpose.
+3. Supported flexible BNO threshold setting, which allows set different BNO thresholds for clusters or set more than 1 threshold for the testing purpose.
 
 See the Quick Start in `./embyte/example/1_Quick_start_water_dimmer_test` for more details.
 
 ### PBC&OBC Supported
 
 EmByte supports calculations on systems using open boundary conditions (OBC) or periodic boundary conditions (PBC). For OBC systems, all computations are performed on-the-fly. This means that aside from necessary checkpoint saving or data required for subsequent calculations (which are typically very small), all other variables are generated as needed and discarded after use. This approach greatly alleviates the pressure caused by I/O operations.
-For PBC systems, however, Cholesky Decomposition Electron Repulsion Integrals (CDERI) must be precomputed and stored on disk. It will be repeatedly readed during SIE calculation. While some asynchronous operations are utilized to prevent excessive I/O consumption, this overhead remains significant in extremely large systems. Efforts will be made in future versions to address this issue.
+For PBC systems, however, Cholesky Decomposition Electron Repulsion Integrals (CDERI) must be precomputed and stored on disk. It will be repeatedly read during SIE calculation. While some asynchronous operations are utilized to prevent excessive I/O consumption, this overhead remains significant in extremely large systems. Efforts will be made in future versions to address this issue.
 
 See the OBC example in `./embyte/example/1_Quick_start_water_dimmer_test`.
 
 See the PBC example in `./embyte/example/2_PBC_example_water@BN`.
 
 ### MPI Parallel Acceleration
-EmByte supports MPI parallelization based on `mpi4py`, which can be used to accelerate the calculation of large systems. Basiscally, after MPI being set， like the node information or others, the MPI parallel could be done like
+EmByte supports MPI parallelization based on `mpi4py`, which can be used to accelerate the calculation of large systems. Basically, after MPI being set, like the node information or others, the MPI parallel could be done like
 ```
 mpirun -n $NODE python SIE_script.py
 ```
@@ -34,10 +34,10 @@ mpirun -np 2 \ # 2 is the number of the GPUs you want to use
 ```
 Note that for now, only the MPI with `openmpi` as the backend is supported.
 ### Checkpoint System
-`EmByte` will defaultly record checkpoint to prevent losses from unexpected computation interruptions. If the program is accidentally halted, you can directly rerun the script without changing the script and logfile. The system will automatically resume the calculation from the most recent checkpoint prior to the interruption.
+`EmByte` will by default record checkpoint to prevent losses from unexpected computation interruptions. If the program is accidentally halted, you can directly rerun the script without changing the script and logfile. The system will automatically resume the calculation from the most recent checkpoint prior to the interruption.
 
 ## Cite
-If you use `EmByte` in your research, except the `ByteQC` paper, please cite the following paper:
+If you use `EmByte` in your research, in addition to the `ByteQC` paper, please cite the following paper:
 
 [1] Nusspickel M, Booth G H. Systematic improvability in quantum embedding for real materials[J]. *Physical Review X*, 2022, 12(1): 011046.
 

--- a/embyte/example/3_E_int_cal_water@coronene/README.md
+++ b/embyte/example/3_E_int_cal_water@coronene/README.md
@@ -1,7 +1,7 @@
 # SIE+CCSD(T) Framework, Take Water(2-leg)@Coronene as an Example
 
 ## Run the Scripts
-Please run the examples in in order of their index.
+Please run the examples in order of their index.
 ```
 python 1_HF.py
 python 2_MP2.py
@@ -10,26 +10,26 @@ python 3-1_SIE.py or 3-2_SIE_with_symm.py
  - `1_HF.py` run GPU accelerated HF calculation for Water@Coronene. The HF calculation is supported by `byteqc.cuobc.scf.RHF`.
  - `2_MP2.py` run GPU accelerated MP2 calculation for Water@Coronene. The MP2 calculation is supported by `byteqc.cump2.DFMP2`.
  - `3-1_SIE.py` run GPU accelerated SIE calculation for Water@Coronene.
- - `3-2_SIE_with_symm.py` run GPU accelerated SIE calculation for Water@Coronene by using the symmetry of this system, which could save about 3/4 computational cost comparing with `3-1_SIE.py`.
+ - `3-2_SIE_with_symm.py` run GPU accelerated SIE calculation for Water@Coronene by using the symmetry of this system, which could save about 3/4 computational cost compared with `3-1_SIE.py`.
 
 ## Get Energy
 As discussed in [our work](https://arxiv.org/abs/2412.18553), the total energy for SIE+CCSD(T) with bath truncation error correction is
 $$
 E_{\text{tot}} = E_{\text{HF}} + E_{\text{corr}},
 $$ 
-where $E_{\text{HF}}$ is the HF energy coming from the `1_HF.py`. and $E_{\text{corr}}$ is the correlation energy comes from the post-HF method. In SIE+CCSD(T), $E_{\text{corr}}$ is
+where $E_{\text{HF}}$ is the HF energy coming from the `1_HF.py`. and $E_{\text{corr}}$ is the correlation energy coming from the post-HF method. In SIE+CCSD(T), $E_{\text{corr}}$ is
 $$
 E_{\text{corr}} = E_{\text{SIE+CCSD(T)}} + (E_{\text{MP2}} - E_{\text{SIE+MP2}}),
 $$
-where the $E_{\text{SIE+CCSD(T)}}$ is the correaltion energy of comes from bare SIE+CCSD(T) calculation and the difference from MP2 and SIE+MP2, $(E_{\text{MP2}} - E_{\text{SIE+MP2}})$, is for the bath truncation error correction. $E_{\text{MP2}}$ comes from the `2_MP2.py`.
+where the $E_{\text{SIE+CCSD(T)}}$ is the correlation energy comes from bare SIE+CCSD(T) calculation and the difference from MP2 and SIE+MP2, $(E_{\text{MP2}} - E_{\text{SIE+MP2}})$, is for the bath truncation error correction. $E_{\text{MP2}}$ comes from the `2_MP2.py`.
 
 The $E_{\text{SIE+CCSD(T)}}$ could be obtained from the `3-1_SIE.py` or `3-2_SIE_with_symm.py` by setting the parameter `if_MP2` to `False` and `SIE_class.in_situ_T` to `True`. The $E_{\text{SIE+MP2}}$ could be also obtained from the `3-1_SIE.py` or `3-2_SIE_with_symm.py` by setting the parameter `if_MP2` to `True`.
 
-Notably, $E_{\text{SIE+CCSD(T)}}$ and $E_{\text{SIE+MP2}}$ should be obtained at the some threshold setting. And the option of `SIE_class.RDM` is highly recommanded to be `True` to using global 1-RDM and in-cluster 2-RDM to obtained correaltion energy, which is more accurate than it turning off.
+Notably, $E_{\text{SIE+CCSD(T)}}$ and $E_{\text{SIE+MP2}}$ should be obtained at the same threshold setting. And the option of `SIE_class.RDM` is highly recommended to be `True` to using global 1-RDM and in-cluster 2-RDM to obtained correlation energy, which is more accurate than it turning off.
 
-## Interacting Energy Calcultion & Basis Set Superposition Error Correction
+## Interacting Energy Calculation & Basis Set Superposition Error Correction
 The interacting energy between water and coronene with basis set superposition error correction is defined as
 $$
 E_{\text{int}} = E_{\text{tot}}(\text{water + coronene}) - E_{\text{tot}}(\text{water + ghost-coronene}) - E_{\text{tot}}(\text{ghost-water + coronene}),
 $$
-where the $E_{\text{tot}}$ is calculated in the workflow above, the ghost-water or ghost-coronene means the water or coronene is set as the ghost atom. It is very easy to achieve in all scripts by just setting the `mol_type` to `2`, `1` or `0`. `mol_type = 2` the scripts will excute the calcualtion for water + coronene system, `mol_type = 1` is for ghost-water + coronene and `mol_type = 0` is for water + ghost-coronene. Note that, when `mol_type` is modified, the corresponding fragments would also be modified by excluding the ghost fragment which do not contain any occupied orbitals.
+where the $E_{\text{tot}}$ is calculated in the workflow above, the ghost-water or ghost-coronene means the water or coronene is set as the ghost atom. It is very easy to achieve in all scripts by just setting the `mol_type` to `2`, `1` or `0`. `mol_type = 2` the scripts will execute the calculation for water + coronene system, `mol_type = 1` is for ghost-water + coronene and `mol_type = 0` is for water + ghost-coronene. Note that, when `mol_type` is modified, the corresponding fragments would also be modified by excluding the ghost fragment which do not contain any occupied orbitals.

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,7 +1,7 @@
 # `lib` subpackage
 
-This subpackages contains some utilities for GPU codeing. All interfaces are exported in the `__init__.py` file, thus can be call directly from `lib` subpackage, e.g. `lib.empty`.
-Some fucntions are adapted form the <https://github.com/cupy/cupy> to extents its features.
+This subpackage contains some utilities for GPU coding. All interfaces are exported in the `__init__.py` file, thus can be called directly from `lib` subpackage, e.g. `lib.empty`.
+Some functions are adapted from the <https://github.com/cupy/cupy> to extend its features.
 
 ## Array related - `array.py`
 
@@ -17,39 +17,39 @@ MemoryTypeManagedNumpy = 3  # managed and prefetched to cpu
 MemoryTypeManagedCupy = 4  # managed and prefetched to gpu
 ```
 
-* `emptyfrombuf` is similar as `empty`. But has a addtional parameter as the first parameter `x`, which can be `None` and falls back to `empty`. If it is a `ndarray` it will used this array to created a new array without allocations. If `x` is not big enough, a error will be raised.
+* `emptyfrombuf` is similar as `empty`. But has an additional parameter as the first parameter `x`, which can be `None` and falls back to `empty`. If it is a `ndarray` it will use this array to create a new array without allocations. If `x` is not big enough, an error will be raised.
 
-* `fillrand` is used to fill a exist `cupy` array with random values. It is similar to the `cupy.random.rand`, but without allocation and support the complex number.
+* `fillrand` is used to fill an existing `cupy` array with random values. It is similar to the `cupy.random.rand`, but without allocation and support complex numbers.
 
-* `ArrayBuffer` class is designed to preallocat a large `numpy`/`cupy` array as the buffer. `ArrayBuffer.empty` for allocation and `ArrayBuffer.asarray` for allocation of a `cupy` array and copy a `numpy` array to it. `ArrayBuffer.tag` and `ArrayBuffer.loadtag` can save/load the current pointer of the buffer. `ArrayBuffer.untag` will delete the saved tag after load it.
+* `ArrayBuffer` class is designed to preallocate a large `numpy`/`cupy` array as the buffer. `ArrayBuffer.empty` for allocation and `ArrayBuffer.asarray` for allocation of a `cupy` array and copy a `numpy` array to it. `ArrayBuffer.tag` and `ArrayBuffer.loadtag` can save/load the current pointer of the buffer. `ArrayBuffer.untag` will delete the saved tag after load it.
 
 ### Managed memory related
 
-Two class `ManagedNumpy` and `ManagedCupy` is defined, they are subclass of `numpy.ndarray` and `cupy.ndarray` respectively but with managed memory as the backends. This two class can be tranform to each other without change the backend memeory: `ManagedNumpy.tocupy` and `ManagedCupy.tonumpy`.
+Two classes `ManagedNumpy` and `ManagedCupy` are defined, they are subclass of `numpy.ndarray` and `cupy.ndarray` respectively but with managed memory as the backends. These two classes can be transformed to each other without change the backend memory: `ManagedNumpy.tocupy` and `ManagedCupy.tonumpy`.
 
-Functions `prefetch` and `advise` are used to change the behavior of the managed memory, more informations can be found in the [cuda documatations](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#unified-memory-programming).
+Functions `prefetch` and `advise` are used to change the behavior of the managed memory, more information can be found in the [CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#unified-memory-programming).
 
 ## File related - `file.py`
 
-This is a multiprocess extension to the `h5py` class. To enable it, user should first open a file as `FileMp` instead of `h5py`. When create database, using the `blksizes` parameter to specify the block size and thus enable the multiprocess. Each block is storage as individual files and their read/write is done in parallel. If `blksizes` is not specified, it falls back to the original `h5py.create_dataset`. For example:
+This is a multiprocess extension to the `h5py` class. To enable it, user should first open a file as `FileMp` instead of `h5py`. When creating a database, using the `blksizes` parameter to specify the block size and thus enable the multiprocess. Each block is stored as individual files and their read/write is done in parallel. If `blksizes` is not specified, it falls back to the original `h5py.create_dataset`. For example:
 
 ```python
 import ByteQC
 f = ByteQC.lib.FileMp('filename.dat', 'w')
 a = f.create_dataset('name', (20,20,20), blksizes=(10, 15))  # a is sliced into 2*2*1=4 slices.
-a[:10,:15] = 1  # this will not triger multiprocess writing because it only involved one block
-print(a[:10])  # this will triger multiprocess reading because it involved two block
+a[:10,:15] = 1  # this will not trigger multiprocess writing because it only involved one block
+print(a[:10])  # this will trigger multiprocess reading because it involves two blocks
 ```
 
-Function `set_num_threads` is used to set the number of threads used in the multiprocess. It only effect the operations after it is called.
+Function `set_num_threads` is used to set the number of threads used in the multiprocess. It only affects the operations after it is called.
 
-Sliceing `h5py.DataSet` will return a `numpy` array, while here a `FutureNumpy` is returned and the i/o operation may be not done when it is returned, that is, sliceing operation is asynchronized. `FutureNumpy` is subclass of `numpy.ndarray`, and all attributes that do not rely on the data itself will behave the same as `numpy.ndarray`, while others will first wait the i/o operation to be complete. Thus there are no need to change the code for this features, but will affect the timeing logic.
+Slicing `h5py.DataSet` will return a `numpy` array, while here a `FutureNumpy` is returned and the i/o operation may be not done when it is returned, that is, slicing operation is asynchronized. `FutureNumpy` is subclass of `numpy.ndarray`, and all attributes that do not rely on the data itself will behave the same as `numpy.ndarray`, while others will first wait the i/o operation to be complete. Thus there is no need to change the code for this feature, but will affect the timing logic.
 
 ## Linalg related - `linalg.py`
 
-This file export several linear algebra functions:
+This file exports several linear algebra functions:
 
-* `contraction` will automatically check whether `numpy.ndarray` is passed in. If `numpy.ndarray`s' size is less than `MG_NBYTES_THRESHOLD` bytes (default `1GB`) for `a` and `b`, they are transfered to GPU automatically. After that, if any tensor is still on cpu, the `cutensorMg` is used (one can also set `isforceMg=True` to force using `cutensorMg`). Otherwise, the `cutensor` is used. For contraction between real numbers and complex numbers, there is a trick to enhance the performance: reparse the complex array as a real one with additional axies with extent `2`. This trick is enabled by default and can be closed by setting `isskipc2r=True`. `DEFAULT_WS_HOST` is the default value of parameter `ws_host`.
+* `contraction` will automatically check whether `numpy.ndarray` is passed in. If `numpy.ndarray`s' size is less than `MG_NBYTES_THRESHOLD` bytes (default `1GB`) for `a` and `b`, they are transferred to GPU automatically. After that, if any tensor is still on cpu, the `cutensorMg` is used (one can also set `isforceMg=True` to force using `cutensorMg`). Otherwise, the `cutensor` is used. For contraction between real numbers and complex numbers, there is a trick to enhance the performance: reparse the complex array as a real one with additional axes with extent `2`. This trick is enabled by default and can be closed by setting `isskipc2r=True`. `DEFAULT_WS_HOST` is the default value of parameter `ws_host`.
 
 * `elementwise_binary` calculates the `out = opac(alpha * opa(A), gamma * opc(C))` using cuTENSOR library.
 
@@ -59,33 +59,33 @@ This file export several linear algebra functions:
 
   * `numpy` array is passed in;
   * arrays passed in are not contiguous;
-  * arrays passed in have different types. (This by default will triger the complex-to-real trick mentioned above.)
+  * arrays passed in have different types. (This by default will trigger the complex-to-real trick mentioned above.)
 
-* `svd` call the 64-bit `cusolver.xgesvd` backend, and support all the features of CUDA level functions. No cpu array is allowed.
+* `svd` calls the 64-bit `cusolver.xgesvd` backend, and supports all the features of CUDA level functions. No cpu array is allowed.
 
-* `solve_triangle` solve the equation `op(a) x = alpha * b` for `x` if `left=True` and `x op(a) = alpha * b` if `left=False`.
+* `solve_triangle` solves the equation `op(a) x = alpha * b` for `x` if `left=True` and `x op(a) = alpha * b` if `left=False`.
 
-* `cholesky` perform the Cholesky decomposition and can modify input array in-place with `overwrite=True`.
+* `cholesky` performs the Cholesky decomposition and can modify input array in-place with `overwrite=True`.
 
-* `scal` scale a array by a scalar in-place. For cpu arrays it is much faster as the naive implementation `arr *= c`. For gpu arrays the performance is similar.
+* `scal` scales an array by a scalar in-place. For cpu arrays it is much faster than the naive implementation `arr *= c`. For gpu arrays the performance is similar.
 
-* `copy` copy array `x` to array `y`.  For cpu arrays it is much faster as the naive implementation `y[:] = x`. For gpu arrays the performance is similar.
+* `copy` copies array `x` to array `y`.  For cpu arrays it is much faster than the naive implementation `y[:] = x`. For gpu arrays the performance is similar.
 
-* `axpy`: in-place modify `yarr` as `a*xarr+yarr`.  It is much faster as the naive implementation `yarr[:] += a*xarr`. No extra memory is needed for `axpy` while naive implementation demanding an extra memory of size of `xarr`
+* `axpy`: in-place modify `yarr` as `a*xarr+yarr`.  It is much faster than the naive implementation `yarr[:] += a*xarr`. No extra memory is needed for `axpy` while naive implementation demanding an extra memory of size of `xarr`
 
-* `swap` in-place swap `xarr` and `yarr`. It change the memory while `x, y = y, x` only swap the pointers.
+* `swap` in-place swaps `xarr` and `yarr`. It changes the memory while `x, y = y, x` only swaps the pointers.
 
 ## Multigpu related - `multigpu.py`
 
-The only bindings exported by this file is the `Mg` object. The backend communicator is initialed at first used.
+The only bindings exported by this file are the `Mg` object. The backend communicator is initialized at first used.
 
-`Mg.set_gpu(gpus)` will (re)init the `Mg`. `gpus` can be `None` for all gpus, a int `n` for first `n` gpus, and a list of int specify which gpu to use.
+`Mg.set_gpu(gpus)` will (re)init the `Mg`. `gpus` can be `None` for all gpus, an int `n` for first `n` gpus, and a list of integers specifying which gpu to use.
 
-`Mg.getgid()` will return the current gpu index in the `Mg.gpus` instead of the gpu id. Because `Mg.gpus` can be incontiguous or nor in ascend order.
+`Mg.getgid()` will return the current gpu index in the `Mg.gpus` instead of the gpu id. Because `Mg.gpus` can be incontiguous or not in ascending order.
 
 `Mg.sum` and `Mg.reduce` both sum over the arrays in different gpus. The difference is all arrays are equal to the summation for `Mg.sum` while only the `root`th gpu in `Mg.gpus` equals to the summation for `Mg.reduce`. The former can use the ring-broadcast and has better performance. But if arrays not in the `root`th gpu should not be modified, `Mg.reduce` should be used.
 
-The function use to `sum` or `reduce` must as the follow form:
+The function used to `sum` or `reduce` must be in the following form:
 
 ```python
 def task(r, ...):
@@ -95,17 +95,17 @@ def task(r, ...):
   return r
 ```
 
-`Mg.map` map a function into various parameters and return a list, which contain the results for all parameters. Which parameter calculated on which gpu is random. The parameter is automatically broadcsasted unless the parameter length cannot be determined (in such case `length` parameter should be passed in). e.g.
+`Mg.map` map a function into various parameters and return a list, which contain the results for all parameters. Which parameter calculated on which gpu is random. The parameter is automatically broadcast unless the parameter length cannot be determined (in such case `length` parameter should be passed in). e.g.
 
 ```python
-Ma.map(f, range(10), 3)  # return [f(0, 3), f(1, 3),... f(9, 3)]
-Ma.map(f, range(10), 3, length=2)  # return [f(0, 3), f(1, 3)]
+Mg.map(f, range(10), 3)  # return [f(0, 3), f(1, 3),... f(9, 3)]
+Mg.map(f, range(10), 3, length=2)  # return [f(0, 3), f(1, 3)]
 ```
 
 `Mg.broadcast` broadcasts a cpu/gpu array into all gpus.
 
-`Mg.mapgpu` is similar to `Mg.map`, but the `length` is fix to the number of gpus and `i`th parameter is calculated on `i`th gpu in `Mg.gpus`.
+`Mg.mapgpu` is similar to `Mg.map`, but the `length` is fixed to the number of gpus and `i`th parameter is calculated on `i`th gpu in `Mg.gpus`.
 
 ## Other utils - `utils.py`
 
-Here exports `is_pinned`, `gpu_avail_bytes`, `gpu_used_bytes`, `free_all_blocks`, `pool_status`, `pack_tril`, `unpack_tril`, and `hasnan` with the detailed explanation in he doc strings.
+Here exports `is_pinned`, `gpu_avail_bytes`, `gpu_used_bytes`, `free_all_blocks`, `pool_status`, `pack_tril`, `unpack_tril`, and `hasnan` with the detailed explanation in the doc strings.


### PR DESCRIPTION
## Summary

Fix 80 spelling and grammar issues across 7 documentation files:

- **lib/README.md** (47 fixes): misspellings (`codeing` → `coding`, `fucntions` → `functions`, `memeory` → `memory`, `preallocat` → `preallocate`, etc.), subject-verb agreement (`support` → `supports`, `call` → `calls`), article corrections (`a error` → `an error`), and one code example bug (`Ma.map` → `Mg.map` to match the `Mg` variable described in prose)
- **embyte/README.md** (10 fixes): `perfermance` → `performance`, `thershould` → `threshold`, fullwidth commas → ASCII, `Basiscally` → `Basically`
- **README.md** (3 fixes): `Exteranl` → `External`, `dependencied` → `dependencies`
- **embyte/example/3_E_int_cal_water@coronene/README.md** (11 fixes): `correaltion` → `correlation`, `recommanded` → `recommended`, `excute` → `execute`, `Calcultion` → `Calculation`, duplicated `in in` → `in`
- **cump2/README.md** (2 fixes): `advance` → `advanced`, subject-verb agreement
- **cucc/README.md** (1 fix): `packages` → `package`
- **cuobc/README.md** (1 fix): `form` → `from`

No functional changes — documentation only.